### PR TITLE
Allow to suppress notifications sound/vibration if screen is On [2/2]

### DIFF
--- a/res/values/x_strings.xml
+++ b/res/values/x_strings.xml
@@ -1023,4 +1023,8 @@
     <string name="adb_notify">ADB notification</string>
     <string name="adb_notify_summary">Display a notification when android debugging is enabled</string>
 
+    <!-- Notifications while screen on -->
+    <string name="notification_sound_vib_screen_on_title">Noisy notifications if screen on</string>
+    <string name="notification_sound_vib_screen_on_summary">Play sound and vibration for notifications when screen is on</string>
+
 </resources>

--- a/res/xml/x_settings_notifications.xml
+++ b/res/xml/x_settings_notifications.xml
@@ -31,6 +31,12 @@
         android:summary="@string/less_boring_heads_up_summary"
         android:defaultValue="false" />
 
+    <com.msm.xtended.preferences.SystemSettingSwitchPreference
+        android:key="notification_sound_vib_screen_on"
+        android:title="@string/notification_sound_vib_screen_on_title"
+        android:summary="@string/notification_sound_vib_screen_on_summary"
+        android:defaultValue="true" />
+
     <PreferenceCategory
         android:title="@string/light_settings_header" >
 


### PR DESCRIPTION
Suppress notification vib/sound feature: add "if no media playing" mode [2/2]

Cleanup: Remove notifications media playing check [2/2]

The media playing check for "Suppress notifications when screen on" is not
reliable. The other two available options are enough.